### PR TITLE
Fix internal links

### DIFF
--- a/apps/CrawlInternalLinksEightyApp.js
+++ b/apps/CrawlInternalLinksEightyApp.js
@@ -25,7 +25,7 @@ var EightyApp = function() {
 			if(link != null) {
 				try {
 		                        var linkDomain = link.match(r)[1];
-					if (urlDomain == linkDomain) {
+					if (urlDomain.toLowerCase() == linkDomain.toLowerCase()) {
 						links.push(link);
 					}
 				} catch (err) {

--- a/apps/DocumentsAndImages.js
+++ b/apps/DocumentsAndImages.js
@@ -124,7 +124,7 @@ var EightyApp = function() {
                     var linkDomain = link.match(r);
 	                if (linkDomain && linkDomain.length > 1) {
 	                    linkDomain = linkDomain[1];
-				    if (urlDomain == linkDomain)
+				    if (urlDomain.toLowerCase() == linkDomain.toLowerCase())
 				        links.push(link);
 	               }
 			    }
@@ -148,5 +148,3 @@ try {
     console.log("Eighty app exists.");
     EightyApp.prototype = new EightyAppBase();
 }
-
-

--- a/apps/DomainCollector.js
+++ b/apps/DomainCollector.js
@@ -45,10 +45,10 @@ var EightyApp = function() {
 
 			    if (link != null) {
                     var linkDomain = link.match(r);
-	                if (linkDomain && linkDomain.length > 1) {
-	                    linkDomain = linkDomain[1];
-				    if (urlDomain == linkDomain)
-				        links.push(link);
+                    if (linkDomain && linkDomain.length > 1) {
+                        linkDomain = linkDomain[1];
+                    if (urlDomain.toLowerCase() == linkDomain.toLowerCase())
+                        links.push(link);
 	               }
 			    }
 		});

--- a/apps/EmailCollector.js
+++ b/apps/EmailCollector.js
@@ -31,10 +31,10 @@ var EightyApp = function() {
 
 			if (link != null) {
                 var linkDomain = link.match(r);
-	            if (linkDomain && linkDomain.length > 1) {
-	                linkDomain = linkDomain[1];
-				    if (urlDomain == linkDomain)
-				        links.push(link);
+                if (linkDomain && linkDomain.length > 1) {
+                    linkDomain = linkDomain[1];
+                if (urlDomain.toLowerCase() == linkDomain.toLowerCase())
+                    links.push(link);
 	            }
 			}
 		});

--- a/apps/InternalLinkCollector.js
+++ b/apps/InternalLinkCollector.js
@@ -14,14 +14,14 @@ var EightyApp = function() {
                 $html.find('a').each(function(i, obj) {
                     if ($(this).attr('href')) {
                         var link = app.makeLink(url, $(this).attr('href'));
-			            if (link != null) {
-                            var linkDomain = link.match(r);
-	                        if (linkDomain && linkDomain.length > 1) {
-	                            linkDomain = linkDomain[1];
-				                if (urlDomain == linkDomain)
-				                    links.push(link);
-	                       }
-			            }
+			        if (link != null) {
+                        var linkDomain = link.match(r);
+                        if (linkDomain && linkDomain.length > 1) {
+                            linkDomain = linkDomain[1];
+                            if (urlDomain.toLowerCase() == linkDomain.toLowerCase())
+				                links.push(link);
+	                    }
+			        }
 			        }
                 });
 
@@ -46,10 +46,10 @@ var EightyApp = function() {
 
 			    if (link != null) {
                     var linkDomain = link.match(r);
-	                if (linkDomain && linkDomain.length > 1) {
-	                    linkDomain = linkDomain[1];
-				    if (urlDomain == linkDomain)
-				        links.push(link);
+                    if (linkDomain && linkDomain.length > 1) {
+                        linkDomain = linkDomain[1];
+                    if (urlDomain.toLowerCase() == linkDomain.toLowerCase())
+                        links.push(link);
 	               }
 			    }
 		    });

--- a/apps/KeywordCount.js
+++ b/apps/KeywordCount.js
@@ -49,12 +49,12 @@ var EightyApp = function() {
 			// console.log($(this).attr('href'));
 			var link = app.makeLink(url, $(this).attr('href'));
 
-			    if (link != null) {
+                if (link != null) {
                     var linkDomain = link.match(r);
-	                if (linkDomain && linkDomain.length > 1) {
-	                    linkDomain = linkDomain[1];
-				    if (urlDomain == linkDomain)
-				        links.push(link);
+                    if (linkDomain && linkDomain.length > 1) {
+                        linkDomain = linkDomain[1];
+                    if (urlDomain.toLowerCase() == linkDomain.toLowerCase())
+                        links.push(link);
 	               }
 			    }
 		});

--- a/apps/KeywordCountPass80Flag.js
+++ b/apps/KeywordCountPass80Flag.js
@@ -58,7 +58,7 @@ var EightyApp = function() {
                 if (linkDomain && linkDomain.length > 1) {
                     linkDomain = linkDomain[1];
 				    // only crawl link if domain is the same of current URL
-				    if (urlDomain == linkDomain) {
+				    if (urlDomain.toLowerCase() == linkDomain.toLowerCase()) {
 					    var eightyvalue = app.get80Value(url);
 					    link = app.append80FlagToLink(eightyvalue, link);
 					    links.push(link);

--- a/apps/KeywordCountWith80Flag.js
+++ b/apps/KeywordCountWith80Flag.js
@@ -53,7 +53,7 @@ var EightyApp = function() {
                 if (linkDomain && linkDomain.length > 1) {
                     linkDomain = linkDomain[1];
 				    // only crawl link if domain is the same of current URL
-				    if (urlDomain == linkDomain) {
+				    if (urlDomain.toLowerCase() == linkDomain.toLowerCase()) {
 					    link = app.append80FlagToLink("your value here", link);
 					    links.push(link);
 				    }

--- a/apps/LossyPageContentInternalLinks.js
+++ b/apps/LossyPageContentInternalLinks.js
@@ -42,7 +42,7 @@ var EightyApp = function() {
                     var linkDomain = link.match(r);
 	                if (linkDomain && linkDomain.length > 1) {
 	                    linkDomain = linkDomain[1];
-				    if (urlDomain == linkDomain)
+				    if (urlDomain.toLowerCase() == linkDomain.toLowerCase())
 				        links.push(link);
 	               }
 			    }


### PR DESCRIPTION
The internal link collectors were only collecting internal links when they had the same cases. For example, the link collectors would not collect `eXample.com` if the current domain was `example.com`. Sometimes websites like to stylize the case of their `href` values. This PR addresses those cases.

If you need a good example page to test different stylizations of the `href` value, please let me know.